### PR TITLE
mask dtype to bool

### DIFF
--- a/model.py
+++ b/model.py
@@ -195,7 +195,7 @@ class ProteinGCN(nn.Module):
 
 		max_idx                 = torch.max(atom_amino_idx)
 		min_idx                 = torch.min(atom_amino_idx)
-		mask_pooled             = atom_amino_idx.new_full(size=(max_idx+1,1), fill_value=1, dtype=torch.uint8)
+		mask_pooled             = atom_amino_idx.new_full(size=(max_idx+1,1), fill_value=1, dtype=torch.bool)
 		mask_pooled[:min_idx]   = 0
 		pooled                  = scatter_add(atom_emb.t(), atom_amino_idx).t()
 


### PR DESCRIPTION
The warning is thrown while running train.py for a trial run: masked_select received a mask with dtype torch.uint8, this behavior is now deprecated, please use a mask with dtype torch.bool instead.

When dtype is set to uint8, the trial run completes, but the repeated warning messages make the output less interpretable. 